### PR TITLE
[RELEASE-0.3.0]: Changes for Reference Data Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Within this architecture, there are two key types of microservices:
 
 Following is the helm version chart against geo-addressing PDX docker image version and GA-SDK version.
 
-| Helm Chart Version → <br> Docker Image Version & GA-SDK Version ↓ | `0.1.0` - `0.2.0` |
+| Helm Chart Version → <br> Docker Image Version & GA-SDK Version ↓ | `0.1.0` - `0.3.0` |
 |-------------------------------------------------------------------|-------------------|
 | `999.638.718/2023.9/Sept 12, 2023` & `5.1.488`                    | ✔️                |
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Within this architecture, there are two key types of microservices:
 
 Following is the helm version chart against geo-addressing PDX docker image version and GA-SDK version.
 
-| Docker Image Version & GA-SDK Version                           | Helm Chart Version |
-|-----------------------------------------------------------------|--------------------|
-| `999.638.718/2023.9/Sept 12, 2023` & `5.1.488`                  | `0.1.0` - `0.3.0`️ |
+| Docker Image PDX Version & GA-SDK Version     | Helm Chart Version |
+|-----------------------------------------------|--------------------|
+| `999.638.718/2023.9/Sept 12,2023` & `5.1.488` | `0.1.0` - `0.3.0`️ |
 
+> NOTE: The docker images pushed to the image repository should be tagged with the current helm chart version. Refer [Downloading Geo-Addressing Docker Images](docs/guides/eks/QuickStartEKS.md#step-3-download-geo-addressing-docker-images) for more information.
+ 
 ## Miscellaneous
 
 - [Metrics](docs/MetricsAndTraces.md#generating-insights-from-metrics)

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Within this architecture, there are two key types of microservices:
 
 Following is the helm version chart against geo-addressing PDX docker image version and GA-SDK version.
 
-| Helm Chart Version → <br> Docker Image Version & GA-SDK Version ↓ | `0.1.0` - `0.3.0` |
-|-------------------------------------------------------------------|-------------------|
-| `999.638.718/2023.9/Sept 12, 2023` & `5.1.488`                    | ✔️                |
+| Docker Image Version & GA-SDK Version                           | Helm Chart Version |
+|-----------------------------------------------------------------|--------------------|
+| `999.638.718/2023.9/Sept 12, 2023` & `5.1.488`                  | `0.1.0` - `0.3.0`️ |
 
 ## Miscellaneous
 

--- a/charts/geo-addressing/Chart.yaml
+++ b/charts/geo-addressing/Chart.yaml
@@ -3,25 +3,25 @@ name: geo-addressing
 description: A Helm chart for Geo Addressing service
 
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.16.0"
 dependencies:
   - name: addressing-hook
     repository: file://charts/addressing-hook
-    version: "0.2.0"
+    version: "0.3.0"
   - name: addressing-svc
     repository: file://charts/addressing-svc
-    version: "0.2.0"
+    version: "0.3.0"
     condition: addressing-svc.enabled
   - name: autocomplete-svc
     repository: file://charts/autocomplete-svc
-    version: "0.2.0"
+    version: "0.3.0"
     condition: autocomplete-svc.enabled
   - name: lookup-svc
     repository: file://charts/lookup-svc
-    version: "0.2.0"
+    version: "0.3.0"
     condition: lookup-svc.enabled
   - name: reverse-svc
     repository: file://charts/reverse-svc
-    version: "0.2.0"
+    version: "0.3.0"
     condition: reverse-svc.enabled

--- a/charts/geo-addressing/README.md
+++ b/charts/geo-addressing/README.md
@@ -48,7 +48,7 @@ provided by this chart:
 | Parameter          | Description                                         | Default                       |
 |--------------------|-----------------------------------------------------|-------------------------------|
 | `image.repository` | the regional-addressing container image repository  | `regional-addressing-service` |
-| `image.tag`        | the regional-addressing container image version tag | `latest`                      |
+| `image.tag`        | the regional-addressing container image version tag | `0.3.0`                       |
 
 <hr>
 </details>
@@ -73,7 +73,7 @@ provided by this chart:
 | `global.countries`                                | this parameter enables the provided country for an addressing functionality. A comma separated value can be provided to enable a particular set of countries from: `usa,gbr,deu,aus,fra,can,mex,bra,arg,rus,ind,sgp,nzl,jpn,world` | `{usa,gbr,aus,nzl,can}` |
 | `global.awsRegion`                                | the region for where elastic file system is present.                                                                                                                                                                               | `us-east-1`             |
 | `global.addressingImage.repository`               | the addressing-service container image repository                                                                                                                                                                                  | `addressing-service`    |
-| `global.addressingImage.tag`                      | the addressing-service container image version tag                                                                                                                                                                                 | `latest`                |
+| `global.addressingImage.tag`                      | the addressing-service container image version tag                                                                                                                                                                                 | `0.3.0`                 |
 | `global.efs.fileSystemId`                         | the fileSystemId of the elastic file system (e.g. fs-0d49e756a)                                                                                                                                                                    | `fileSystemId`          |
 | `global.efs.addressingBasePath`                   | the base path of the folder where verify-geocode data is present                                                                                                                                                                   | `verify-geocode`        |
 | `global.efs.autoCompleteBasePath`                 | the base path of the folder where autocomplete data is present                                                                                                                                                                     | `autocomplete`          |

--- a/charts/geo-addressing/charts/addressing-hook/Chart.yaml
+++ b/charts/geo-addressing/charts/addressing-hook/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geo-addressing/charts/addressing-svc/Chart.yaml
+++ b/charts/geo-addressing/charts/addressing-svc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geo-addressing/charts/autocomplete-svc/Chart.yaml
+++ b/charts/geo-addressing/charts/autocomplete-svc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geo-addressing/charts/lookup-svc/Chart.yaml
+++ b/charts/geo-addressing/charts/lookup-svc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geo-addressing/charts/reverse-svc/Chart.yaml
+++ b/charts/geo-addressing/charts/reverse-svc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geo-addressing/values.yaml
+++ b/charts/geo-addressing/values.yaml
@@ -157,22 +157,22 @@ global:
     ##
     ## The base path where the data is present for verify-geocode functionalities.
     ##
-    ## [NOTE]: if your data for verify-geocode is not present in the format `verify-geocode/[country]/[vintage]`, this parameter needs to be overridden.
+    ## [NOTE]: if your data for verify-geocode is not present in the format `verify-geocode/[country]/[timestamp]/[vintage]`, this parameter needs to be overridden.
     addressingBasePath: verify-geocode
     ##
     ## The base path where the data is present for verify-geocode functionality.
     ##
-    ## [NOTE]: if your data for autocomplete is not present in the format `autocomplete/[country]/[vintage]`, this parameter needs to be overridden.
+    ## [NOTE]: if your data for autocomplete is not present in the format `autocomplete/[country]/[timestamp]/[vintage]`, this parameter needs to be overridden.
     autoCompleteBasePath: autocomplete
     ##
     ## The base path where the data is present for lookup functionality.
     ##
-    ## [NOTE]: if your data for lookup is not present in the format lookup/[country]/[vintage], this parameter needs to be overridden.
+    ## [NOTE]: if your data for lookup is not present in the format lookup/[country]/[timestamp]/[vintage], this parameter needs to be overridden.
     lookupBasePath: lookup
     ##
     ## The base path where the data is present for reverse-geocode functionality.
     ##
-    ## [NOTE]: if your data for reverse-geocode is not present in the format verify-geocode/[country]/[vintage], this parameter needs to be overridden.
+    ## [NOTE]: if your data for reverse-geocode is not present in the format verify-geocode/[country]/[timestamp]/[vintage], this parameter needs to be overridden.
     ##
     ## [NOTE]: the data used for reverse-geocode is the exactly same, that's why the default value is set to verify-geocode.
     reverseBasePath: verify-geocode

--- a/charts/geo-addressing/values.yaml
+++ b/charts/geo-addressing/values.yaml
@@ -6,14 +6,13 @@
 replicaCount: 1
 
 ## Configuration for the regional-addressing-service container image.
-## We recommend that you always download the latest version of the regional-addressing-image before running the Helm chart.
 ##
 ## - Please visit the official 'Precisely Data Experience' website to download container images:
 ##   https://data.precisely.com/products
 image:
   repository: regional-addressing-service
   pullPolicy: Always
-  tag: latest
+  tag: 0.3.0
 imagePullSecrets: [ ]
 
 ## This will override the name of the installed regional-addressing deployment.
@@ -137,14 +136,13 @@ global:
   awsRegion: us-east-1
 
   ## Configurations for the addressing-service container image.
-  ## We strongly recommend that you always download the latest version of the addressing-image before running the Helm chart.
   ##
   ## To download container images, please visit the official 'Precisely Data Experience' website:
   ## https://data.precisely.com/products
   addressingImage:
     repository: addressing-service
     pullPolicy: Always
-    tag: latest
+    tag: 0.3.0
 
   ## Configurations related to AWS Elastic File System
   efs:

--- a/charts/reference-data-setup/Chart.yaml
+++ b/charts/reference-data-setup/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: reference-data
 description: A Helm chart for Installation of Reference Data
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.16.0"

--- a/charts/reference-data-setup/README.md
+++ b/charts/reference-data-setup/README.md
@@ -24,7 +24,7 @@ Follow the below steps to create and push the docker image to ECR:
 
 ```shell
 cd ./charts/reference-data-setup/image
-docker build . -t reference-data-extractor:latest
+docker build . -t reference-data-extractor:0.3.0
 ```
 
 ```shell
@@ -32,9 +32,9 @@ aws ecr get-login-password --region us-east-1 | docker login --username AWS --pa
 
 aws ecr create-repository --repository-name reference-data-extractor --image-scanning-configuration scanOnPush=true --region [AWS-REGION]
 
-docker tag reference-data-extractor:latest [AWS-ACCOUNT-ID].dkr.ecr.[AWS-REGION].amazonaws.com/reference-data-extractor:latest
+docker tag reference-data-extractor:0.3.0 [AWS-ACCOUNT-ID].dkr.ecr.[AWS-REGION].amazonaws.com/reference-data-extractor:0.3.0
 
-docker push [AWS-ACCOUNT-ID].dkr.ecr.[AWS-REGION].amazonaws.com/reference-data-extractor:latest
+docker push [AWS-ACCOUNT-ID].dkr.ecr.[AWS-REGION].amazonaws.com/reference-data-extractor:0.3.0
 ```
 
 ## Step 3: Creating EFS
@@ -70,7 +70,7 @@ provided by this chart:
 | Parameter          | Description                                              | Default                    |
 |--------------------|----------------------------------------------------------|----------------------------|
 | `image.repository` | the reference-data-extractor container image repository  | `reference-data-extractor` |
-| `image.tag`        | the reference-data-extractor container image version tag | `latest`                   |
+| `image.tag`        | the reference-data-extractor container image version tag | `0.3.0`                    |
 
 <hr>
 </details>

--- a/charts/reference-data-setup/image/reference_data_extractor.py
+++ b/charts/reference-data-setup/image/reference_data_extractor.py
@@ -228,7 +228,7 @@ def download_spds_to_local(products_list, spd_base_path, country_name):
             urllib.request.urlretrieve(url, file_path)
 
 
-def extract_spds_to_mount_path(country_path_value, extract_path_value, country_name):
+def extract_spds_to_mount_path(country_path_value, extract_path_value, country_name, current_date_folder):
     for f in os.listdir(country_path_value):
         country_spd_path = os.path.join(country_path_value, f)
         try:
@@ -238,6 +238,7 @@ def extract_spds_to_mount_path(country_path_value, extract_path_value, country_n
                     metadata = json.loads(data)
                     extract_path_spd = os.path.join(extract_path_value,
                                                     country_name,
+                                                    current_date_folder,
                                                     metadata['vintage'],
                                                     metadata['qualifier'])
                     os.makedirs(extract_path_spd, exist_ok=True)
@@ -253,6 +254,7 @@ PDX_SECRET = args.pdx_api_secret
 REQUIRED_COUNTRIES = args.countries
 LOCAL_PATH = args.local_path
 COUNTRY_MAPPING = args.data_mapping
+date_folder = str(time.strftime("%Y%m%d%H%M"))
 
 if not COUNTRY_MAPPING:
     COUNTRY_MAPPING = COUNTRY_SPD_MAPPING
@@ -302,9 +304,9 @@ for addressing_type, country_mapping in COUNTRY_MAPPING.items():
                     "or the pdx data is accessible.")
 
             try:
-                extract_spds_to_mount_path(country_path, os.path.join(extract_path, addressing_type), country)
+                extract_spds_to_mount_path(country_path, os.path.join(extract_path, addressing_type), country, date_folder)
             except Exception as ex:
-                raise Exception(f'Exception while extracting spds to local for {country}: {ex}', ex)
+                raise Exception(f'Exception while extracting spds for {country}: {ex}', ex)
 
             try:
                 print(f'Deleting local directories: {country_path}')
@@ -315,7 +317,7 @@ for addressing_type, country_mapping in COUNTRY_MAPPING.items():
                     f"StdOut: {e.stdout}, StdErr: {e.stderr}")
         except Exception as ex:
             print(ex)
-            print(f'Data download and extraction to s3 process is not successful for {country}. '
+            print(f'Data download and extraction process is not successful for {country}. '
                   f'Please run the setup again for {country} by fixing the issues.')
             pass
 

--- a/charts/reference-data-setup/values.yaml
+++ b/charts/reference-data-setup/values.yaml
@@ -3,7 +3,7 @@ dataDownload:
   image:
     repository: reference-data-extractor
     pullPolicy: Always
-    tag: latest
+    tag: 0.3.0
     pullSecrets: [ ]
 
 nameOverride: "reference-data"

--- a/charts/reference-data-setup/values.yaml
+++ b/charts/reference-data-setup/values.yaml
@@ -28,7 +28,7 @@ global:
     - nzl
   efs:
     fileSystemId: fileSystemId
-  dataConfigMap: "{\"verify-geocode\":{\"usa\":[\"Geocoding MLD US#United States#All USA#Spectrum Platform Data\",\"Geocoding NT Street US#United States#All USA#Spectrum Platform Data\"],\"aus\":[\"Geocoding PSMA Street#Australia#All AUS#Geocoding\",\"Geocoding GNAF Address Point#Australia#All AUS#Geocoding\"]},\"lookup\":{\"usa\":[\"Geocoding MLD US#United States#All USA#Spectrum Platform Data\",\"Geocoding NT Street US#United States#All USA#Spectrum Platform Data\"],\"aus\":[\"Geocoding PSMA Street#Australia#All AUS#Geocoding\",\"Geocoding GNAF Address Point#Australia#All AUS#Geocoding\"]},\"autocomplete\":{\"usa\":[\"Predictive Addressing Points#United States#All USA#Interactive\"],\"aus\":[\"Predictive Addressing Points#Australia#All AUS#Interactive\"]}}"
+  dataConfigMap: "{\"verify-geocode\":{\"usa\":[\"Geocoding MLD US#United States#All USA#Spectrum Platform Data\",\"Geocoding NT Street US#United States#All USA#Spectrum Platform Data\",\"Extended Attrib#United States#All USA#Spectrum Platform Data\"],\"aus\":[\"Geocoding PSMA Street#Australia#All AUS#Geocoding\",\"Geocoding GNAF Address Point#Australia#All AUS#Geocoding\"]},\"lookup\":{\"usa\":[\"Geocoding MLD US#United States#All USA#Spectrum Platform Data\",\"Geocoding NT Street US#United States#All USA#Spectrum Platform Data\",\"Extended Attrib#United States#All USA#Spectrum Platform Data\"],\"aus\":[\"Geocoding PSMA Street#Australia#All AUS#Geocoding\",\"Geocoding GNAF Address Point#Australia#All AUS#Geocoding\"]},\"autocomplete\":{\"usa\":[\"Predictive Addressing Points#United States#All USA#Interactive\"],\"aus\":[\"Predictive Addressing Points#Australia#All AUS#Interactive\"]}}"
 
 volumes:
   - name: geoaddressing-host-volume

--- a/docs/ReferenceData.md
+++ b/docs/ReferenceData.md
@@ -27,40 +27,46 @@ seamlessly and with zero downtime.
 # Reference Data Structure
 
 As a generalized step, the reference data should exist in the following format only:
-<br>`[basePath]/[addressing-functionality]/[country]/[vintage]/[data]`
+<br>`[basePath]/[addressing-functionality]/[country]/[current-time]/[vintage]/[data]`
 
-
+NOTE: The current-time folder name should always be in the format: `YYMMDDhhmm` e.g. 202311081159
 ```
 basePath/
 ├── verify-geocode/
 │   │── usa/
-│   │   └── 202306/
-│   │       ├── data-folder-1/
-│   │       └── ...
+│   │   └── 202311081159/
+│   │       └── 202306/
+│   │           ├── data-folder-1/
+│   │           └── ...
 │   │── gbr/
-│   │   └── 202307/
-│   │       ├── data-folder-1/
-│   │       └── ...
+│   │   └── 202311081159/
+│   │       └── 202307/
+│   │           ├── data-folder-1/
+│   │           └── ...
 │   │── ...
 ├── autocomplete/
 │   │── usa/
-│   │   └── 202309/
-│   │       ├── data-folder-1/
-│   │       └── ...
+│   │   └── 202311081159/
+│   │       └── 202309/
+│   │           ├── data-folder-1/
+│   │           └── ...
 │   │── aus/
-│   │   └── 202308/
-│   │       ├── data-folder-1/
-│   │       └── ...
+│   │   └── 202311081159/
+│   │       └── 202308/
+│   │           ├── data-folder-1/
+│   │           └── ...
 │   │── ...
 ├── lookup/
 │   │── usa/
-│   │   └── 202309/
-│   │       ├── data-folder-1/
-│   │       └── ...
+│   │   └── 202311081159/
+│   │       └── 202309/
+│   │           ├── data-folder-1/
+│   │           └── ...
 │   │── fra/
-│   │   └── 202308/
-│   │       ├── data-folder-1/
-│   │       └── ...
+│   │   └── 202311081159/
+│   │       └── 202308/
+│   │           ├── data-folder-1/
+│   │           └── ...
 ```
 
 # Reference Data Installation

--- a/docs/guides/eks/QuickStartEKS.md
+++ b/docs/guides/eks/QuickStartEKS.md
@@ -84,10 +84,10 @@ pip install -r requirements.txt
 python upload_ecr.py --pdx-api-key [pdx-api-key] --pdx-api-secret [pdx-secret] --aws-access-key [aws-access-key] --aws-secret [aws-secret] --aws-region [aws-region]
 ```
 
-There are two docker container images which will be pushed to ECR:
+There are two docker container images which will be pushed to ECR with the tag of helm chart version.
 
-1. regional-addressing-service:latest
-2. addressing-service:latest
+1. regional-addressing-service
+2. addressing-service
 
 For more details related to docker images download script, follow the
 instructions [here](../../../scripts/images-to-ecr-uploader/README.md)
@@ -133,6 +133,8 @@ helm install reference-data ./charts/reference-data-setup/ \
 ```
 
 ## Step 6: Installation of Geo-Addressing Helm Chart
+
+> NOTE: For every helm chart version update, make sure you run the [Step 3](#step-3-download-geo-addressing-docker-images) for uploading the docker images with the newest tag.
 
 To install/upgrade the geo-addressing helm chart, use the following command:
 

--- a/scripts/images-to-ecr-uploader/README.md
+++ b/scripts/images-to-ecr-uploader/README.md
@@ -37,6 +37,6 @@ The following command downloads the docker images from PDX and uploads it to you
 >
 
 ```console
-python upload_ecr.py --pdx-api-key [pdx-api-key] --pdx-api-secret [pdx-secret] --aws-access-key [aws-access-key] --aws-secret [aws-secret] --aws-region [aws-region]
+python upload_ecr.py --pdx-api-key [pdx-api-key] --pdx-api-secret [pdx-secret] --aws-access-key [aws-access-key] --aws-secret [aws-secret] --aws-region [aws-region] --docker-tag latest
 ```
 [🔗 Return to `Table of Contents` 🔗](../../README.md#components)

--- a/scripts/images-to-ecr-uploader/README.md
+++ b/scripts/images-to-ecr-uploader/README.md
@@ -37,6 +37,6 @@ The following command downloads the docker images from PDX and uploads it to you
 >
 
 ```console
-python upload_ecr.py --pdx-api-key [pdx-api-key] --pdx-api-secret [pdx-secret] --aws-access-key [aws-access-key] --aws-secret [aws-secret] --aws-region [aws-region] --docker-tag latest
+python upload_ecr.py --pdx-api-key [pdx-api-key] --pdx-api-secret [pdx-secret] --aws-access-key [aws-access-key] --aws-secret [aws-secret] --aws-region [aws-region]
 ```
 [🔗 Return to `Table of Contents` 🔗](../../README.md#components)

--- a/scripts/images-to-ecr-uploader/upload_ecr.py
+++ b/scripts/images-to-ecr-uploader/upload_ecr.py
@@ -153,10 +153,6 @@ def get_argument_parser():
     parser.add_argument('--aws-secret-key', dest='aws_secret_key',
                 help='AWS Account secret key',
                 required=False)
-    parser.add_argument('--docker-tag', dest='docker_tag',
-                        help='The image tag version',
-                        default='latest',
-                        required=False)
     return parser.parse_args()
 
 
@@ -202,7 +198,7 @@ LOCAL_PATH = args.local_path
 AWS_REGION = args.aws_region
 AWS_ACCESS_KEY = args.aws_access_key
 AWS_SECRET_KEY = args.aws_secret_key
-image_tag = args.docker_tag
+image_tag = '0.3.0'
 date_folder = str(time.strftime("%Y%m%d%H%M"))
 
 if not AWS_REGION:

--- a/scripts/images-to-ecr-uploader/upload_ecr.py
+++ b/scripts/images-to-ecr-uploader/upload_ecr.py
@@ -189,7 +189,7 @@ def download_spd_to_local(product_url, spd_base_path):
     urllib.request.urlretrieve(product_url, file_path)
     return file_path
 
-def extract_spds_to_mount_path(country_path_value, extract_path_value, country_name):
+def extract_spds_to_mount_path(country_path_value, extract_path_value, country_name, current_date_folder):
     for f in os.listdir(country_path_value):
         country_spd_path = os.path.join(country_path_value, f)
         try:
@@ -199,6 +199,7 @@ def extract_spds_to_mount_path(country_path_value, extract_path_value, country_n
                     metadata = json.loads(data)
                     extract_path_spd = os.path.join(extract_path_value,
                                                     country_name,
+                                                    current_date_folder,
                                                     metadata['vintage'],
                                                     metadata['qualifier'])
                     os.makedirs(extract_path_spd, exist_ok=True)
@@ -215,6 +216,7 @@ LOCAL_PATH = args.local_path
 AWS_REGION = args.aws_region
 AWS_ACCESS_KEY = args.aws_access_key
 AWS_SECRET_KEY = args.aws_secret_key
+date_folder = str(time.strftime("%Y%m%d%H%M"))
 
 if not AWS_REGION:
     AWS_REGION = "us-east-1"

--- a/scripts/images-to-ecr-uploader/upload_ecr.py
+++ b/scripts/images-to-ecr-uploader/upload_ecr.py
@@ -153,6 +153,10 @@ def get_argument_parser():
     parser.add_argument('--aws-secret-key', dest='aws_secret_key',
                 help='AWS Account secret key',
                 required=False)
+    parser.add_argument('--docker-tag', dest='docker_tag',
+                        help='The image tag version',
+                        default='latest',
+                        required=False)
     return parser.parse_args()
 
 
@@ -189,24 +193,6 @@ def download_spd_to_local(product_url, spd_base_path):
     urllib.request.urlretrieve(product_url, file_path)
     return file_path
 
-def extract_spds_to_mount_path(country_path_value, extract_path_value, country_name, current_date_folder):
-    for f in os.listdir(country_path_value):
-        country_spd_path = os.path.join(country_path_value, f)
-        try:
-            if f.endswith('.spd'):
-                with ZipFile(country_spd_path, "r") as zip_ref:
-                    data = zip_ref.read('metadata.json')
-                    metadata = json.loads(data)
-                    extract_path_spd = os.path.join(extract_path_value,
-                                                    country_name,
-                                                    current_date_folder,
-                                                    metadata['vintage'],
-                                                    metadata['qualifier'])
-                    os.makedirs(extract_path_spd, exist_ok=True)
-                unzip(extract_path_spd, country_spd_path)
-        except Exception as exp:
-            raise exp
-
 
 args = get_argument_parser()
 
@@ -216,6 +202,7 @@ LOCAL_PATH = args.local_path
 AWS_REGION = args.aws_region
 AWS_ACCESS_KEY = args.aws_access_key
 AWS_SECRET_KEY = args.aws_secret_key
+image_tag = args.docker_tag
 date_folder = str(time.strftime("%Y%m%d%H%M"))
 
 if not AWS_REGION:
@@ -292,13 +279,13 @@ try:
                     shell=True, stderr=subprocess.STDOUT, encoding="utf-8"))
 
                 print(subprocess.check_output(
-                    f'docker tag {file_name_withour_ext}:latest {ecr_url}/{file_name_withour_ext}:latest',
+                    f'docker tag {file_name_withour_ext}:latest {ecr_url}/{file_name_withour_ext}:{image_tag}',
                     shell=True, stderr=subprocess.STDOUT, encoding="utf-8"))
                 
                 print(subprocess.check_output(
-                    f'docker push {ecr_url}/{file_name_withour_ext}:latest',
+                    f'docker push {ecr_url}/{file_name_withour_ext}:{image_tag}',
                     shell=True, stderr=subprocess.STDOUT, encoding="utf-8"))
-                images[file_name_withour_ext] = f'{ecr_url}/{file_name_withour_ext}:latest'
+                images[file_name_withour_ext] = f'{ecr_url}/{file_name_withour_ext}:{image_tag}'
 
             except Exception as ex:
                 print(f"Exception: {ex}, Output: {ex.output}, StdOut: {ex.stdout}, StdErr: {ex.stderr}")


### PR DESCRIPTION
**What's Changed?:**

1. As there might be different vintages for different reference data files for multiple countries, the data should always be installed in the folder with the current timestamp to avoid vintage mapping.
2. The upload script now uploads the docker images to ECR with the tag of current helm chart version.